### PR TITLE
Configurações de banco de dados / typeORM #5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Configurações do Banco de Dados
+DB_HOST=localhost
+DB_PORT=5432
+DB_USERNAME=seu_usuario
+DB_PASSWORD=sua_senha
+DB_DATABASE=nome_do_banco

--- a/package.json
+++ b/package.json
@@ -23,8 +23,12 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/typeorm": "^10.0.2",
+    "dotenv": "^16.4.5",
+    "pg": "^8.12.0",
     "reflect-metadata": "^0.2.0",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "typeorm": "^0.3.20"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,9 +2,25 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { TeacherModule } from './teacher/teacher.module';
+import { TypeOrmModule } from '@nestjs/typeorm'; 
+import * as dotenv from 'dotenv';
+
+dotenv.config();
 
 @Module({
-  imports: [TeacherModule],
+    imports: [
+    TypeOrmModule.forRoot({
+      type: 'postgres',  
+      host: process.env.DB_HOST,
+      port: parseInt(process.env.DB_PORT, 10),
+      username: process.env.DB_USERNAME,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_DATABASE,
+      entities: [], //Adicionar aqui as entidades
+      synchronize: true,
+    }),
+    TypeOrmModule.forFeature([TeacherModule]),
+  ],
   controllers: [AppController],
   providers: [AppService],
 })


### PR DESCRIPTION
Necessário configurar o `.env` de acordo com o exemplo:

```
# Configurações do Banco de Dados
DB_HOST=localhost
DB_PORT=5432
DB_USERNAME=seu_usuario
DB_PASSWORD=sua_senha
DB_DATABASE=nome_do_banco
```